### PR TITLE
fix(deps): override uuid to ^14.0.0 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17756,13 +17756,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "url-loader": "4.1.1"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "uuid": "^14.0.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert [#115](https://github.com/techblog-szksh-cloud/techblog-szksh-cloud.github.io/security/dependabot/115) — medium-severity buffer-bounds bug in `uuid <14.0.0` (GHSA-w5hq-g745-h8pq, CVSS 6.3).
- Reaches us transitively: `@docusaurus/core` → `webpack-dev-server@5` → `sockjs@0.3.24` → `uuid@8.3.2`. Patch is only in `14.0.0`, so the parents' `^8.3.2` range can't pick it up.
- Adds an npm `overrides` entry forcing `uuid` to `^14.0.0`. Lockfile resolves to `14.0.0`. `npm audit` now reports zero vulnerabilities.

## Why the override is safe even though uuid@14 is ESM-only
`uuid@14` is `type: "module"` and would break a CommonJS `require('uuid')`. The only consumer in our tree is `sockjs`, which `webpack-dev-server@5` requires **only** from `lib/servers/SockJSServer.js` — loaded just when `webSocketServer.type === 'sockjs'`. Docusaurus uses the default `ws` transport, so `sockjs` is never required at runtime. `npm run build` doesn't include `webpack-dev-server` at all.

The actual exploit surface is also zero: the bug is in `uuid.v3/v5/v6` with caller-supplied `buf`/`offset`, and `sockjs` only calls `uuid.v4()` with no args. We're clearing the alert proactively rather than fixing a real exploit.

## Test plan
- [x] `npm install` resolves `uuid` to `14.0.0` (`npm ls uuid` → `…sockjs@0.3.24 → uuid@14.0.0`)
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run build` (Docusaurus production build) succeeds
- [x] `npm start` serves the homepage; the `/ws` WebSocket opens and closes cleanly (no `ERR_REQUIRE_ESM` from sockjs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)